### PR TITLE
Putting lock.lock() before try{} in MyBlockingQueue

### DIFF
--- a/src/com/lld/myblockingqueue/MyBlockingQueue.java
+++ b/src/com/lld/myblockingqueue/MyBlockingQueue.java
@@ -30,9 +30,8 @@ public class MyBlockingQueue<E> {
     public void put(E item) throws InterruptedException {
         Objects.requireNonNull(item);
 
+        lock.lock();
         try {
-            lock.lock();
-
             while (size.get() == capacity) {
                 canPut.await();
             }
@@ -48,9 +47,8 @@ public class MyBlockingQueue<E> {
     }
 
     public E get() throws InterruptedException {
+        lock.lock();
         try {
-            lock.lock();
-
             while (size.get() == 0) {
                 canTake.await();
             }

--- a/src/com/lld/myblockingqueue/Producer.java
+++ b/src/com/lld/myblockingqueue/Producer.java
@@ -1,7 +1,5 @@
 package com.lld.myblockingqueue;
 
-import java.util.Random;
-
 public class Producer implements Runnable {
     private MyBlockingQueue<Integer> myBlockingQueue;
 


### PR DESCRIPTION
`lock.lock()` should not be put in `try{}`. If put inside `try`, in case `lock()` throws an `InterruptedException`, the thread will not be able to get the lock and when `finally` is called, the thread will try to `unlock()` the lock which it has not really acquired in the first place. This will cause `IllegalMonitorStateException`.